### PR TITLE
Visualize overlap in parameter space

### DIFF
--- a/Topdown_GlobalRs.Rmd
+++ b/Topdown_GlobalRs.Rmd
@@ -563,7 +563,9 @@ variance_decomp(bootstrap_gpp_draws, "GPP2", var(gpp_results$GPP2), calc_bootstr
 ### Input pairs
 ```{r gpp-input-pairs, results='show'}
 lt_ip <- gpp_results$GPP < gpp_ip  # "<" b/c most bootstrapped GPP values are above
-pairs_colors <- c("black", "red")[as.factor(lt_ip)]
+black <- rgb(0, 0, 0, alpha = 0.25)
+red <- rgb(1, 0, 0, alpha = 1)
+pairs_colors <- c(black, red)[as.factor(lt_ip)]
 pairsdata <- gpp_results[gpp_vd$Parameter[gpp_vd$Contribution > 0.05]]
 pairs(pairsdata, col = pairs_colors, main = "GPP")
 ```
@@ -835,7 +837,7 @@ variance_decomp(bootstrap_rs_draws, "Rs_topdown2",
 ### Input pairs
 ```{r rs-input-pairs, results='show'}
 gt_ip <- rs_results$Rs_topdown > rs_ip  # ">" b/c most bootstrapped Rs values are below
-pairs_colors <- c("black", "red")[as.factor(gt_ip)]
+pairs_colors <- c(black, red)[as.factor(gt_ip)]
 pairsdata <- rs_results[vd_rs$Parameter[vd_rs$Contribution > 0.05]]
 pairs(pairsdata, col = pairs_colors, main = "Rs")
 ```

--- a/Topdown_GlobalRs.Rmd
+++ b/Topdown_GlobalRs.Rmd
@@ -299,7 +299,7 @@ var_other_froot <- Froot[Froot$IGBP2 == "Other",]$Froot # samples of Froot for n
 # Bootstrap settings
 RESAMPLE <- method3
 RESAMPLE_noSD <- method1
-N_SAMPLES <- 10000
+N_SAMPLES <- 5000 # this is max shapiro.test() size
 sample_size <- 10
 QUANTILES <- c(0.025, 0.5, 0.975)  # Generate mean and 95% CI
 set.seed(20190827)
@@ -386,7 +386,6 @@ calc_bootstrap_gpp <- function(x) {
 
 gpp_results <- calc_bootstrap_gpp(bootstrap_gpp_draws)
 ```
-
 
 ## GPP results {.tabset .tabset-fade .tabset-pills}
 ### Scenario 1 - ratio __not__ weighted by ecosystem
@@ -541,21 +540,10 @@ ggplot(gpp_results, aes(x = 1-Froot, y = GPP2)) +
   ylab(expression(GPP~(Pg~C~yr^{-1})))
 ```
 
-### Probability of agreement
-```{r gpp-agreement, cache=FALSE}
-p_gpp1 <- prob_agreement(gpp_results$GPP, gpp_qt_raw)
-p_gpp2 <- prob_agreement(gpp_results$GPP2, gpp_qt_raw)
-p_gpp3 <- prob_agreement(ratio_results$GPP, gpp_qt_raw)
-p_gpp1_tt <- t_test(gpp_results$GPP_raw, gpp_results$GPP)
-p_gpp2_tt <- t_test(gpp_results$GPP_raw, gpp_results$GPP2)
-p_gpp3_tt <- t_test(gpp_results$GPP_raw, ratio_results$GPP)
+### Overlap
+```{r gpp-overlap, cache=FALSE, results='show'}
+calc_overlap(gpp_results$GPP_raw, gpp_results$GPP, intersection_interval = c(100, 150))
 ```
-
-Scenario                 | Agreement (quantiles) | p-value (t.test)
------------------------- | --------------------- | -----------------
-1 (no weighting)         | `r p_gpp1 * 100` %     | `r p_gpp1_tt`
-2 (weighting)            | `r p_gpp2 * 100` %     | `r p_gpp2_tt`
-3 (global Rs:GPP)        | `r p_gpp3 * 100` %     | `r p_gpp3_tt`
 
 ### Variance decomposition
 ```{r gpp-variance-decomp, results='show'}
@@ -771,11 +759,6 @@ rs_results %>% select(`RA = GPP * Ra-GPP ratio` = Ra1, `RA = GPP - NPP` = Ra2) %
 
 ggsave("outputs/FigureS6_RA_Method.jpg", width = 8, height = 4, dpi = 300, units = "in")
 
-
-
-
-
-
 # Rs ~ GPP
 ggplot(rs_results, aes(GPP_raw, Rs_topdown)) +
   geom_hex() +
@@ -817,22 +800,10 @@ ggplot(rs_results, aes(Fire, Rs_topdown)) +
   ylab(expression(R[S]~(Pg~C~yr^{-1})))
 ```
 
-### RSG probability of agreement
-
-```{r compute proportion of agreement between top-down RSG and bottom-up RSG, cache=FALSE}
-p_Rs1 <- prob_agreement(rs_results$Rs_topdown, rsg_qt_raw)
-p_Rs2 <- prob_agreement(rs_results$Rs_topdown2, rsg_qt_raw)
-p_Rs3 <- prob_agreement(ratio_results$Rs, rsg_qt_raw)
-p_Rs1_tt <- t_test(rs_results$Rs_raw, rs_results$Rs_topdown)
-p_Rs2_tt <- t_test(rs_results$Rs_raw, rs_results$Rs_topdown2)
-p_Rs3_tt <- t_test(rs_results$Rs_raw, ratio_results$Rs)
+### Overlap
+```{r rs-overlap, cache=FALSE, results='show'}
+calc_overlap(rs_results$Rs_topdown, rs_results$Rs_raw, intersection_interval = c(70, 90))
 ```
-
-Scenario                 | Agreement (quantiles) | p-value (t.test)
------------------------- | --------------------- | -----------------
-1 (no weighting)         | `r p_Rs1 * 100` %     | `r p_Rs1_tt`
-2 (weighting)            | `r p_Rs2 * 100` %     | `r p_Rs2_tt`
-3 (simple global Rs:GPP) | `r p_Rs3 * 100` %     | `r p_Rs3_tt`
 
 ### Variance decomposition
 ```{r rs-variance-decomp, results='show'}

--- a/Topdown_GlobalRs.Rmd
+++ b/Topdown_GlobalRs.Rmd
@@ -485,7 +485,6 @@ cat("\n\nTop-down GPP quantiles: ", gpp_qt_raw, "\n")
 ggsave("outputs/Figure1_gpp_simple.jpg", width = 8, height = 4, dpi = 300, units = "in")
 ```
 
-
 ### GPP vs components relationships
 ```{r gpp-vs-components}
 gpp_results %>% ggplot() + aes(Rc) + 
@@ -542,7 +541,8 @@ ggplot(gpp_results, aes(x = 1-Froot, y = GPP2)) +
 
 ### Overlap
 ```{r gpp-overlap, cache=FALSE, results='show'}
-calc_overlap(gpp_results$GPP_raw, gpp_results$GPP, intersection_interval = c(100, 150))
+gpp_ip <- calc_overlap(gpp_results$GPP_raw, gpp_results$GPP, 
+                       intersection_interval = c(100, 150))
 ```
 
 ### Variance decomposition
@@ -550,14 +550,24 @@ calc_overlap(gpp_results$GPP_raw, gpp_results$GPP, intersection_interval = c(100
 variance_decomp(bootstrap_gpp_draws, "GPP", var(gpp_results$GPP), calc_bootstrap_gpp) %>%
   select(Parameter, GPP_variance = variance, Contribution) %>% 
   filter(Contribution > 0) %>% 
-  arrange(desc(Contribution)) %>% 
-  knitr::kable(format = "markdown")
+  arrange(desc(Contribution)) -> 
+  gpp_vd
+knitr::kable(gpp_vd, format = "markdown")
 variance_decomp(bootstrap_gpp_draws, "GPP2", var(gpp_results$GPP2), calc_bootstrap_gpp) %>%
   select(Parameter, GPP2_variance = variance, Contribution) %>% 
   filter(Contribution > 0) %>% 
   arrange(desc(Contribution)) %>% 
   knitr::kable(format = "markdown")
 ```
+
+### Input pairs
+```{r gpp-input-pairs, results='show'}
+lt_ip <- gpp_results$GPP < gpp_ip  # "<" b/c most bootstrapped GPP values are above
+pairs_colors <- c("black", "red")[as.factor(lt_ip)]
+pairsdata <- gpp_results[gpp_vd$Parameter[gpp_vd$Contribution > 0.05]]
+pairs(pairsdata, col = pairs_colors, main = "GPP")
+```
+
 
 ## Bootstrapping RSG
 
@@ -716,7 +726,6 @@ cat("\n\nBottom-up Rs quantiles: ", rsg_qt_raw, "\n")
 ggsave("outputs/Figure1_rs_weighted.jpg", width = 8, height = 4)
 ```
 
-
 ### Scenario 3 - SRDB Rs:GPP ratios
 ```{r SRDB Rs:GPP ratios for RSG, results='asis'}
 # Calculation are the same as above
@@ -802,21 +811,33 @@ ggplot(rs_results, aes(Fire, Rs_topdown)) +
 
 ### Overlap
 ```{r rs-overlap, cache=FALSE, results='show'}
-calc_overlap(rs_results$Rs_topdown, rs_results$Rs_raw, intersection_interval = c(70, 90))
+rs_ip <- calc_overlap(rs_results$Rs_topdown, rs_results$Rs_raw, 
+                      intersection_interval = c(70, 90))
 ```
 
 ### Variance decomposition
 ```{r rs-variance-decomp, results='show'}
-variance_decomp(bootstrap_rs_draws, "Rs_topdown", var(rs_results$Rs_topdown), calc_bootstrap_rs) %>%
+variance_decomp(bootstrap_rs_draws, "Rs_topdown", 
+                var(rs_results$Rs_topdown), calc_bootstrap_rs) %>%
   select(Parameter, Rs_topdown_variance = variance, Contribution) %>% 
   filter(Contribution > 0) %>% 
-  arrange(desc(Contribution)) %>% 
-  knitr::kable(format = "markdown")
-variance_decomp(bootstrap_rs_draws, "Rs_topdown2", var(rs_results$Rs_topdown2), calc_bootstrap_rs) %>%
+  arrange(desc(Contribution)) ->
+  vd_rs 
+knitr::kable(vd_rs, format = "markdown")
+variance_decomp(bootstrap_rs_draws, "Rs_topdown2", 
+                var(rs_results$Rs_topdown2), calc_bootstrap_rs) %>%
   select(Parameter, Rs_topdown2_variance = variance, Contribution) %>% 
   filter(Contribution > 0) %>% 
   arrange(desc(Contribution)) %>% 
   knitr::kable(format = "markdown")
+```
+
+### Input pairs
+```{r rs-input-pairs, results='show'}
+gt_ip <- rs_results$Rs_topdown > rs_ip  # ">" b/c most bootstrapped Rs values are below
+pairs_colors <- c("black", "red")[as.factor(gt_ip)]
+pairsdata <- rs_results[vd_rs$Parameter[vd_rs$Contribution > 0.05]]
+pairs(pairsdata, col = pairs_colors, main = "Rs")
 ```
 
 

--- a/functions-stats.R
+++ b/functions-stats.R
@@ -61,6 +61,10 @@ calc_overlap <- function(left_sample, right_sample, intersection_interval) {
   mu_right <- mean(right_sample)
   sigma_right <- sd(right_sample)
   
+  if(mu_left > mu_right) {
+    stop("It doesn't look like left_sample is actually on the left")  
+  }
+  
   density_left <- density(left_sample, n = 1024)
   normal_fn_left <- function(x) dnorm(x, mean = mu_left, sd = sigma_left)
   numerical_fn_left <- approxfun(x = density_left$x, y = density_left$y)
@@ -98,7 +102,7 @@ calc_overlap <- function(left_sample, right_sample, intersection_interval) {
     annotate("label", x = mu_right, y = 0.01, label = right_normal) ->
     p
   print(p)
-
+  
   # Calculate percentage of each distribution in overlap region
   
   # For vectors of x-axis points `x` and corresponding function evaluation points `y`,

--- a/functions-stats.R
+++ b/functions-stats.R
@@ -44,3 +44,85 @@ t_test <- function(x, y, alternative = "two.sided", ...) {
          ", p-value = ", format(z$p.value, digits = 3, scientific = FALSE))
 }
 
+# Calculate overlap between two bootstrap samples
+# This implements the method laid out in `toyproblem_overlap.Rmd`
+calc_overlap <- function(left_sample, right_sample, intersection_interval) {
+  # Test for normality
+  left_normal_test <- shapiro.test(left_sample)
+  left_normal <- left_normal_test$p.value >= 0.05
+  print(left_normal_test)
+  right_normal_test <- shapiro.test(right_sample)
+  right_normal <- right_normal_test$p.value >= 0.05
+  print(right_normal_test)
+  
+  # Calculate mu, sigma, and both normal and non-normal density functions
+  mu_left <- mean(left_sample)
+  sigma_left <- sd(left_sample)
+  mu_right <- mean(right_sample)
+  sigma_right <- sd(right_sample)
+  
+  density_left <- density(left_sample, n = 1024)
+  normal_fn_left <- function(x) dnorm(x, mean = mu_left, sd = sigma_left)
+  numerical_fn_left <- approxfun(x = density_left$x, y = density_left$y)
+  density_right <- density(right_sample, n = 1024)
+  normal_fn_right <- function(x) dnorm(x, mean = mu_right, sd = sigma_right)
+  numerical_fn_right <- approxfun(x = density_right$x, y = density_right$y)
+  
+  # Decide which density functions we're using
+  if(left_normal) {
+    left_dist <- normal_fn_left
+  } else {
+    left_dist <- numerical_fn_left
+  }
+  if(right_normal) {
+    right_dist <- normal_fn_right
+  } else {
+    right_dist <- numerical_fn_right
+  }
+  
+  # Calculate the intersection point
+  intersection <- uniroot(function(x) (left_dist(x) - right_dist(x)), 
+                          interval = intersection_interval)$root
+  cat("Intersection =", intersection, "Pg C/yr\n")
+  
+  # Plot the distributions and intersection
+  tibble(x = seq(min(left_sample) - 50, max(right_sample) + 50, by = 5),
+         left_normal = normal_fn_left(x),
+         right_normal = normal_fn_right(x),
+         left_non_normal = numerical_fn_left(x),
+         right_non_normal = numerical_fn_right(x)) %>%
+    gather(group, density, -x) %>% 
+    ggplot(aes(x, density, color = group)) + geom_line() + 
+    geom_vline(xintercept = intersection, linetype = 2) +
+    annotate("label", x = mu_left, y = 0.01, label = left_normal) +
+    annotate("label", x = mu_right, y = 0.01, label = right_normal) ->
+    p
+  print(p)
+
+  # Calculate percentage of each distribution in overlap region
+  
+  # For vectors of x-axis points `x` and corresponding function evaluation points `y`,
+  # the area under the curve according to the trapezoidal rule is:
+  traprule <- function(x, y) {
+    sum(diff(x) * (head(y, -1) + tail(y, -1)), na.rm = TRUE) / 2
+  }
+  
+  # Left sample: define the x-axis points for integration
+  dx <- 0.01   # integration step size
+  left_xaxis_range <- seq(intersection, 4 * max(left_sample), by = dx ) # 4 is arbitrary
+  # get the corresponding y-axis values
+  left_yaxis_range <- left_dist(left_xaxis_range)
+  # and get the area under the curve
+  left_auc <- traprule(x = left_xaxis_range, y = left_yaxis_range)
+  # Right sample calculated similarly except we can't go below zero, an easy cutoff
+  right_xaxis_range <- seq(0, intersection, by = dx )
+  right_yaxis_range <- right_dist(right_xaxis_range)
+  right_auc <- traprule(x = right_xaxis_range, y = right_yaxis_range)
+  
+  cat("Left sample overlap =", round(left_auc * 100, 1), "%\n")
+  cat("Right sample overlap =", round(right_auc * 100, 1), "%\n")
+  
+  cat("Left quantile of threshold:", ecdf(left_sample)(intersection), "\n")
+  cat("Right quantile of threshold:", ecdf(right_sample)(intersection), "\n")
+}
+

--- a/functions-stats.R
+++ b/functions-stats.R
@@ -46,6 +46,7 @@ t_test <- function(x, y, alternative = "two.sided", ...) {
 
 # Calculate overlap between two bootstrap samples
 # This implements the method laid out in `toyproblem_overlap.Rmd`
+# Returns the intersection point
 calc_overlap <- function(left_sample, right_sample, intersection_interval) {
   # Test for normality
   left_normal_test <- shapiro.test(left_sample)
@@ -128,5 +129,6 @@ calc_overlap <- function(left_sample, right_sample, intersection_interval) {
   
   cat("Left quantile of threshold:", ecdf(left_sample)(intersection), "\n")
   cat("Right quantile of threshold:", ecdf(right_sample)(intersection), "\n")
+  intersection
 }
 

--- a/toyproblem_overlap.Rmd
+++ b/toyproblem_overlap.Rmd
@@ -176,7 +176,7 @@ If we're justified in making normality assumptions for each of implied, observed
 Regardless of whether we sample 100 or 1000 points from each of our two distributions, the `density` function returns x and y values for a default of n = 512 points making up the smooth density curves plotted above. 
 **NOTE that how `density` goes from 100 to 512 or 1000 to 512 points is unclear to me, but does suggest a dependence on sample size.** Therefore we will specify that the number of points should be our actual sample size. 
 
-So, we will take those `nsample`  points and make convenient functions to evaluate to determine whether a given `variablevalue` lies under both curves (ie in the overlap region between the implied and observed densities).
+So, we will take those `nsample` points and make convenient functions to evaluate to determine whether a given `variablevalue` lies under both curves (ie in the overlap region between the implied and observed densities).
 
 ```{r get density}
 # get the x and y values for the density function from 
@@ -263,7 +263,7 @@ dx <- 0.01
 # evaluation points `y`, the area under the curve according to 
 # the trapezoidal rule is:
 traprule <- function(x, y){
-  sum(diff(x) * (head(y,-1)+tail(y,-1)))/2
+  sum(diff(x) * (head(y,-1)+tail(y,-1)), na.rm = TRUE)/2
 }
 ```
 
@@ -313,7 +313,6 @@ And for the observed, it's the upper tail, so just 1-area: the threshold occurs 
 # numerically extracted pdf we already
 # estimated, ie direct.numerical.obs.fn().
 ecdf(sample.obs)(threshold.value)
-
 
 # and the implied
 ecdf(sample.imp)(threshold.value)


### PR DESCRIPTION
Closes #51 

Visualize first-order effects driving the 'extreme' points that end up in the overlap region--for example, do we absolutely need high GPP plus something else? 

**Note: although this PR is against `master`, it's branched from `overlap`, so merge #62 first.**

Output looks like this (each point is a bootstrap draw of GPP or Rs; red points are in overlap region, visualizing only parameters >5% of output variance):
![gpp](https://user-images.githubusercontent.com/1956468/72700514-16724f00-3b1a-11ea-82c3-5cba36686180.png)

Bootstrap GPPs in the overlap region (i.e. perhaps consistent with top-down GPP) are characterized by low root contribution to soil respiration (`Rc`), and high belowground autotrophic respiration relative to total Ra (`Froot`). So starting from Rs values, Rroot is minimized, and then that's most of Ra and thus GPP stays low. Makes sense I think?

![rs](https://user-images.githubusercontent.com/1956468/72700519-1a05d600-3b1a-11ea-9d28-57e7f7c9c01a.png)

Bootstrap Rs values in the overlap region are primarily characterized by high NPP and GPP. This pushes lots of C belowground, part of which contributes Rs.
